### PR TITLE
Add json_tags_id_camelcase configuration option

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -111,6 +111,8 @@ The `gen` mapping supports the following keys:
 - `emit_all_enum_values`:
   - If true, emit a function per enum type
     that returns all valid enum values.
+- `json_tags_id_camelcase`:
+  - If true, "ID" in json tags will be camelcase. If false, will be uppercase. Defaults to `false`
 - `json_tags_case_style`:
   - `camel` for camelCase, `pascal` for PascalCase, `snake` for snake_case or `none` to use the column name in the DB. Defaults to `none`.
 - `output_batch_file_name`:

--- a/internal/cmd/shim.go
+++ b/internal/cmd/shim.go
@@ -84,6 +84,7 @@ func pluginGoCode(s config.SQLGo) *plugin.GoCode {
 	return &plugin.GoCode{
 		EmitInterface:               s.EmitInterface,
 		EmitJsonTags:                s.EmitJSONTags,
+		JsonTagsIDCamelcase:         s.JsonTagsIDCamelcase,
 		EmitDbTags:                  s.EmitDBTags,
 		EmitPreparedQueries:         s.EmitPreparedQueries,
 		EmitExactTableNames:         s.EmitExactTableNames,

--- a/internal/codegen/golang/field.go
+++ b/internal/codegen/golang/field.go
@@ -42,10 +42,11 @@ func TagsToString(tags map[string]string) string {
 
 func JSONTagName(name string, settings *plugin.Settings) string {
 	style := settings.Go.JsonTagsCaseStyle
+	idCamelcase := settings.Go.JsonTagsIDCamelcase
 	if style == "" || style == "none" {
 		return name
 	} else {
-		return SetCaseStyle(name, style)
+		return SetJSONCaseStyle(name, style, idCamelcase)
 	}
 }
 
@@ -53,6 +54,19 @@ func SetCaseStyle(name string, style string) string {
 	switch style {
 	case "camel":
 		return toCamelCase(name)
+	case "pascal":
+		return toPascalCase(name)
+	case "snake":
+		return toSnakeCase(name)
+	default:
+		panic(fmt.Sprintf("unsupported JSON tags case style: '%s'", style))
+	}
+}
+
+func SetJSONCaseStyle(name string, style string, idCamelcase bool) string {
+	switch style {
+	case "camel":
+		return toJsonCamelCase(name, idCamelcase)
 	case "pascal":
 		return toPascalCase(name)
 	case "snake":
@@ -90,6 +104,28 @@ func toCamelInitCase(name string, initUpper bool) string {
 		}
 		if p == "id" {
 			out += "ID"
+		} else {
+			out += strings.Title(p)
+		}
+	}
+	return out
+}
+
+func toJsonCamelCase(name string, idCamelcase bool) string {
+	out := ""
+	idStr := "ID"
+
+	if idCamelcase {
+		idStr = "Id"
+	}
+
+	for i, p := range strings.Split(name, "_") {
+		if i == 0 {
+			out += p
+			continue
+		}
+		if p == "id" {
+			out += idStr
 		} else {
 			out += strings.Title(p)
 		}

--- a/internal/codegen/golang/gen.go
+++ b/internal/codegen/golang/gen.go
@@ -28,6 +28,7 @@ type tmplCtx struct {
 	SourceName string
 
 	EmitJSONTags              bool
+	JsonTagsIDCamelcase       bool
 	EmitDBTags                bool
 	EmitPreparedQueries       bool
 	EmitInterface             bool
@@ -122,6 +123,7 @@ func generate(req *plugin.CodeGenRequest, enums []Enum, structs []Struct, querie
 	tctx := tmplCtx{
 		EmitInterface:             golang.EmitInterface,
 		EmitJSONTags:              golang.EmitJsonTags,
+		JsonTagsIDCamelcase:       golang.JsonTagsIDCamelcase,
 		EmitDBTags:                golang.EmitDbTags,
 		EmitPreparedQueries:       golang.EmitPreparedQueries,
 		EmitEmptySlices:           golang.EmitEmptySlices,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -119,6 +119,7 @@ type SQLGen struct {
 type SQLGo struct {
 	EmitInterface               bool              `json:"emit_interface" yaml:"emit_interface"`
 	EmitJSONTags                bool              `json:"emit_json_tags" yaml:"emit_json_tags"`
+	JsonTagsIDCamelcase         bool              `json:"json_tags_id_camelcase" yaml:"json_tags_id_camelcase"`
 	EmitDBTags                  bool              `json:"emit_db_tags" yaml:"emit_db_tags"`
 	EmitPreparedQueries         bool              `json:"emit_prepared_queries" yaml:"emit_prepared_queries"`
 	EmitExactTableNames         bool              `json:"emit_exact_table_names,omitempty" yaml:"emit_exact_table_names"`

--- a/internal/config/v_one.go
+++ b/internal/config/v_one.go
@@ -25,6 +25,7 @@ type v1PackageSettings struct {
 	Queries                   Paths      `json:"queries" yaml:"queries"`
 	EmitInterface             bool       `json:"emit_interface" yaml:"emit_interface"`
 	EmitJSONTags              bool       `json:"emit_json_tags" yaml:"emit_json_tags"`
+	JsonTagsIDCamelcase       bool       `json:"json_tags_id_camelcase" yaml:"json_tags_id_camelcase"`
 	EmitDBTags                bool       `json:"emit_db_tags" yaml:"emit_db_tags"`
 	EmitPreparedQueries       bool       `json:"emit_prepared_queries" yaml:"emit_prepared_queries"`
 	EmitExactTableNames       bool       `json:"emit_exact_table_names,omitempty" yaml:"emit_exact_table_names"`
@@ -143,6 +144,7 @@ func (c *V1GenerateSettings) Translate() Config {
 				Go: &SQLGo{
 					EmitInterface:             pkg.EmitInterface,
 					EmitJSONTags:              pkg.EmitJSONTags,
+					JsonTagsIDCamelcase:       pkg.JsonTagsIDCamelcase,
 					EmitDBTags:                pkg.EmitDBTags,
 					EmitPreparedQueries:       pkg.EmitPreparedQueries,
 					EmitExactTableNames:       pkg.EmitExactTableNames,

--- a/internal/plugin/codegen.pb.go
+++ b/internal/plugin/codegen.pb.go
@@ -467,6 +467,7 @@ type GoCode struct {
 	EmitPointersForNullTypes    bool     `protobuf:"varint,22,opt,name=emit_pointers_for_null_types,json=emitPointersForNullTypes,proto3" json:"emit_pointers_for_null_types,omitempty"`
 	QueryParameterLimit         *int32   `protobuf:"varint,23,opt,name=query_parameter_limit,json=queryParameterLimit,proto3,oneof" json:"query_parameter_limit,omitempty"`
 	OutputBatchFileName         string   `protobuf:"bytes,24,opt,name=output_batch_file_name,json=outputBatchFileName,proto3" json:"output_batch_file_name,omitempty"`
+	JsonTagsIDCamelcase         bool     `protobuf:"varint,26,opt,name=json_tags_id_camelcase,json=jsonTagsIdCamelcase,proto3" json:"json_tags_id_camelcase,omitempty"`
 }
 
 func (x *GoCode) Reset() {
@@ -511,6 +512,13 @@ func (x *GoCode) GetEmitInterface() bool {
 func (x *GoCode) GetEmitJsonTags() bool {
 	if x != nil {
 		return x.EmitJsonTags
+	}
+	return false
+}
+
+func (x *GoCode) GetJsonTagsIDCamelcase() bool {
+	if x != nil {
+		return x.JsonTagsIDCamelcase
 	}
 	return false
 }

--- a/internal/plugin/codegen_vtproto.pb.go
+++ b/internal/plugin/codegen_vtproto.pb.go
@@ -172,6 +172,7 @@ func (m *GoCode) CloneVT() *GoCode {
 	r := &GoCode{
 		EmitInterface:             m.EmitInterface,
 		EmitJsonTags:              m.EmitJsonTags,
+		JsonTagsIDCamelcase:       m.JsonTagsIDCamelcase,
 		EmitDbTags:                m.EmitDbTags,
 		EmitPreparedQueries:       m.EmitPreparedQueries,
 		EmitExactTableNames:       m.EmitExactTableNames,
@@ -752,6 +753,9 @@ func (this *GoCode) EqualVT(that *GoCode) bool {
 		return false
 	}
 	if this.EmitJsonTags != that.EmitJsonTags {
+		return false
+	}
+	if this.JsonTagsIDCamelcase != that.JsonTagsIDCamelcase {
 		return false
 	}
 	if this.EmitDbTags != that.EmitDbTags {
@@ -1995,6 +1999,16 @@ func (m *GoCode) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		}
 		i--
 		dAtA[i] = 0x10
+	}
+	if m.JsonTagsIDCamelcase {
+		i--
+		if m.JsonTagsIDCamelcase {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x64
 	}
 	if m.EmitInterface {
 		i--
@@ -3548,15 +3562,25 @@ func (m *GoCode) MarshalToSizedBufferVTStrict(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0x10
 	}
-	if m.EmitInterface {
+	if m.EmitJsonTags {
 		i--
-		if m.EmitInterface {
+		if m.EmitJsonTags {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
 		i--
-		dAtA[i] = 0x8
+		dAtA[i] = 0x10
+	}
+	if m.JsonTagsIDCamelcase {
+		i--
+		if m.JsonTagsIDCamelcase {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x64
 	}
 	return len(dAtA) - i, nil
 }
@@ -4603,6 +4627,9 @@ func (m *GoCode) SizeVT() (n int) {
 		n += 2
 	}
 	if m.EmitJsonTags {
+		n += 2
+	}
+	if m.JsonTagsIDCamelcase {
 		n += 2
 	}
 	if m.EmitDbTags {
@@ -7007,6 +7034,26 @@ func (m *GoCode) UnmarshalVT(dAtA []byte) error {
 			}
 			m.SqlDriver = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 26:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field JsonTagsIDCamelcase", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.JsonTagsIDCamelcase = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := skip(dAtA[iNdEx:])


### PR DESCRIPTION
If json_tags_id_camelcase is true, "ID" in json tags will be camelcase. If false, will be uppercase. Defaults to `false`